### PR TITLE
Fix crashes when run with eglot as a client

### DIFF
--- a/server/main/src/main.rs
+++ b/server/main/src/main.rs
@@ -651,14 +651,16 @@ impl LanguageServerHandling for MinecraftShaderLanguageServer {
                 log_level: String,
             }
 
-            let config: Configuration = from_value(params.settings.as_object().unwrap().get("mcglsl").unwrap().to_owned()).unwrap();
+            if let Some(settings) = params.settings.as_object().unwrap().get("mcglsl") {
+                let config: Configuration = from_value(settings.to_owned()).unwrap();
 
-            info!("got updated configuration"; "config" => params.settings.as_object().unwrap().get("mcglsl").unwrap().to_string());
+                info!("got updated configuration"; "config" => params.settings.as_object().unwrap().get("mcglsl").unwrap().to_string());
 
-            configuration::handle_log_level_change(config.log_level, |level| {
-                self.log_guard = None; // set to None so Drop is invoked
-                self.log_guard = Some(logging::set_logger_with_level(level));
-            })
+                configuration::handle_log_level_change(config.log_level, |level| {
+                    self.log_guard = None; // set to None so Drop is invoked
+                    self.log_guard = Some(logging::set_logger_with_level(level));
+                })
+            }
         });
     }
 


### PR DESCRIPTION
This just handles ConfigurationDidChange events in which the "mcglsl"
key wasn't set without crashing, by ignoring them; if the
configuration changed, but none of our configuration changed, there's
nothing we need to update.

Obviously there is still a lot that can go wrong here, but this allows
running the language server with https://github.com/joaotavora/eglot,
as that language server sends a ConfigurationDidChange on startup if
any configuration is set (including for other language servers).