### PR TITLE
Compute shader with suffixes support and some small fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Minecraft GLSL Shaders Language Server
 ## mcshader-lsp
 
-[![Marketplace Version](https://vsmarketplacebadge.apphb.com/version/strum355.vscode-mc-shader.svg)](https://marketplace.visualstudio.com/items?itemName=strum355.vscode-mc-shader) [![Installs](https://vsmarketplacebadge.apphb.com/installs/strum355.vscode-mc-shader.svg)](https://marketplace.visualstudio.com/items?itemName=strum355.vscode-mc-shader)
+[![Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/strum355.vscode-mc-shader.svg)](https://marketplace.visualstudio.com/items?itemName=strum355.vscode-mc-shader) [![Installs](https://img.shields.io/visual-studio-marketplace/i/strum355.vscode-mc-shader.svg)](https://marketplace.visualstudio.com/items?itemName=strum355.vscode-mc-shader)
 [![license](https://img.shields.io/github/license/Strum355/vscode-mc-shader.svg)](https://github.com/Strum355/mcshader-lsp)
 [![Issues](https://img.shields.io/github/issues-raw/Strum355/mcshader-lsp.svg)](https://github.com/Strum355/mcshader-lsp/issues)
 [![Build Status](https://img.shields.io/drone/build/Strum355/mcshader-lsp)](https://cloud.drone.io/Strum355/mcshader-lsp)

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -25,7 +25,7 @@ export class Extension {
 
   readonly package: {
     version: string
-  } = vscode.extensions.getExtension(this.extensionID)!.packageJSON;
+  } = vscode.extensions.getExtension(this.extensionID)!.packageJSON
 
   public get context(): vscode.ExtensionContext {
     return this.extensionContext

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "publisher": "Strum355",
   "author": "Noah Santschi-Cooney (Strum355)",
   "license": "MIT",
-  "icon": "logo-mini.png",
+  "icon": "logo-min.png",
   "repository": {
     "url": "https://github.com/Strum355/mcshader-lsp"
   },

--- a/server/main/src/diagnostics_parser.rs
+++ b/server/main/src/diagnostics_parser.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, lazy::OnceCell, path::Path};
+use std::{collections::HashMap, cell::OnceCell, path::Path};
 
 use regex::Regex;
 use rust_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};

--- a/server/main/src/main.rs
+++ b/server/main/src/main.rs
@@ -115,6 +115,21 @@ lazy_static! {
             set.insert(format!("shadow_cutout.{}", ext));
             set.insert(format!("shadow_solid.{}", ext));
         }
+        let base_char_num = 'a' as u8;
+        for suffix_num in 0u8..=25u8 {
+            let suffix_char = (base_char_num + suffix_num) as char;
+            set.insert(format!("composite_{}.csh", suffix_char));
+            set.insert(format!("deferred_{}.csh", suffix_char));
+            set.insert(format!("prepare_{}.csh", suffix_char));
+            set.insert(format!("shadowcomp_{}.csh", suffix_char));
+            for i in 1..=99 {
+                let total_suffix = format!("{}_{}", i, suffix_char);
+                set.insert(format!("composite{}.csh", total_suffix));
+                set.insert(format!("deferred{}.csh", total_suffix));
+                set.insert(format!("prepare{}.csh", total_suffix));
+                set.insert(format!("shadowcomp{}.csh", total_suffix));
+            }
+        }
         set
     };
 }


### PR DESCRIPTION
Added compute shader with suffixes linting;
Fixed icon unable to load;
Fixed shields in readme;
Updated to latest rust nightly (or I will not able to compile it on my computer).

Notice: since I'm new in rust, I don't know if `std::cell::OnceCell` is same with `std::lazy::OnceCell`, but my rust version (latest nightly when i set it up yesterday) does not contain `lazy`. I just modded it to pass compiling and doesn't see extra bugs yet. Please check this before merge.

Personal advice: maybe you can delete the dependency to let users choose their own GLSL syntax extension. At least I prefer working with mine, but since this extension depends on vscode-shaders, and his GLSL syntax will override mine, I have to copy my syntax file into his extension in my device to use both my syntax highlight and your language server.